### PR TITLE
feat: consumindo api de noticia patrocinada

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,13 @@
       </div>
 
     </main>
+
+    <div class="news">
+      <div>
+        <span>Noticia patrocinada</span>
+      </div>
+      <p class="title-news-today"></p>
+    </div>
     <script type="module" src="./scripts/app.js"></script>
   </body>
 </html>

--- a/scripts/api.js
+++ b/scripts/api.js
@@ -1,0 +1,10 @@
+export async function getNews(){
+    const response = await fetch ('https://servicodados.ibge.gov.br/api/v3/noticias/?tipo=release')
+    const data = await response.json()
+
+    if (!response.ok){
+        return []        
+    }
+
+    return data.items[0].titulo;
+}

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,8 +1,12 @@
 import { renderLista } from "./ui.js"
+import { renderNoticia } from "./ui.js"
 import { Interesse } from "./interesse.js"
+import { getNews } from "./api.js"
 
 const interesse = new Interesse
 const novoInteresseElemento = document.getElementById('interesse-descricao')
+
+var noticia
 
 function adicionarInteresse() {
   let novoInteresse = novoInteresseElemento.value
@@ -29,6 +33,14 @@ function limparInteresse(){
 async function iniciarProjeto(){
   
   renderLista(interesse.getItems())
+
+  try {
+    noticia = await getNews()
+    renderNoticia(noticia)
+
+  } catch (error){
+    console.log('erro ao carregar as noticias')
+  }
 }
 
 document.addEventListener('DOMContentLoaded',iniciarProjeto)

--- a/scripts/ui.js
+++ b/scripts/ui.js
@@ -3,7 +3,17 @@
  * interesse: string 
  */
 const listaItemsElemento = document.getElementById('lista-interesse')
+const listaNoticiaElemento = document.querySelector('.title-news-today')
 
+export function renderNoticia(noticia){
+    listaNoticiaElemento.innerHTML = ""
+
+    const noticiaElemento = document.createElement('p')
+    noticiaElemento.classList.add('title-news-today')
+
+    noticiaElemento.innerHTML = ` <p>${noticia}</p> `
+    listaNoticiaElemento.appendChild(noticiaElemento)
+}
 export function renderLista(items) {    
     listaItemsElemento.innerHTML = ""
     if (items.length >0) {


### PR DESCRIPTION
requisição para a API do IBGE de notícias utilizando o método fetch(). Após recuperar os dados, converta o resultado para JSON e obtenha o primeiro item da lista na propriedade items. A URL que você deve utilizar é: [servicodados.ibge.gov.br/api/v3/noticias/?tipo=release](http://servicodados.ibge.gov.br/api/v3/noticias/?tipo=release).

Acesse apenas os itens e obtenha a primeira informação contida no array. A informação relevante é o título dessa notícia.